### PR TITLE
Fix test script and update package.json

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+node_modules/

--- a/package.json
+++ b/package.json
@@ -24,5 +24,15 @@
       "email": "chris@chrisumbel.com",
       "web": "http://www.chrisumbel.com"
     }
-  ]
+  ],
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/NaturalNode/node-lapack.git" 
+  },
+  "scripts": {
+    "test": "node ./node_modules/.bin/mocha spec/lapack_spec.js"
+  },
+  "devDependencies": {
+    "mocha": "^2.2.1"
+  }
 }

--- a/spec/lapack_spec.js
+++ b/spec/lapack_spec.js
@@ -1,5 +1,5 @@
 
-var lapack = require('lib/node-lapack');
+var lapack = require('../lib/node-lapack');
 var approxEql = require('./approxEql');
 
 describe('lapack', function() {


### PR DESCRIPTION
You can now run the (included) test script via `npm test`
I also updated some fields of the package.json in general (e.g. npm requires a `repository` field by now)