### PR TITLE
Add cholesky and choleskySolve

### DIFF
--- a/lib/node-lapack/index.js
+++ b/lib/node-lapack/index.js
@@ -29,3 +29,5 @@ exports.qr = lapack.qr;
 exports.lu = lapack.lu;
 exports.sgetrf = lapack.sgetrf;
 exports.sgesv = lapack.sgesv;
+exports.cholesky = lapack.cholesky;
+exports.choleskysolve = lapack.choleskysolve;

--- a/lib/node-lapack/lapack.js
+++ b/lib/node-lapack/lapack.js
@@ -72,7 +72,7 @@ function eye(m) {
 }
 
 function matrixOp(matrix, elementSize, callback) {
-console.log(matrix);
+//console.log(matrix);
     var m = matrix.length;
     var n = matrix[0].length;    
     var f_m = new FFI.Pointer(FORTRAN_INT);

--- a/lib/node-lapack/lapack.js
+++ b/lib/node-lapack/lapack.js
@@ -37,6 +37,7 @@ try {
 			    "pointer", "pointer", "pointer", "pointer", "pointer", 
 			    "pointer", "pointer", "pointer", "pointer", ]],
 	"sgetrf_": ["void", ["pointer", "pointer", "pointer", "pointer", "pointer", "pointer"]],
+	"spotrf_": ["void", ["pointer", "pointer", "pointer", "pointer", "pointer"]],
 	"dgetrf_": ["void", ["pointer", "pointer", "pointer", "pointer", "pointer", "pointer"]],
 	"sgesv_": ["void", ["pointer", "pointer", "pointer", "pointer", "pointer", "pointer", "pointer", "pointer"]]
 	
@@ -76,12 +77,16 @@ function matrixOp(matrix, elementSize, callback) {
     var f_n = new FFI.Pointer(FORTRAN_INT);
     var f_a = fortranArray.jsMatrixToFortranArray(matrix, elementSize);
     var f_lda = new FFI.Pointer(FORTRAN_INT);
+    var f_letter_u = new FFI.Pointer(FORTRAN_CHAR);
+    var f_letter_l = new FFI.Pointer(FORTRAN_CHAR);
     
+    f_letter_u.putChar(85);
+    f_letter_l.putChar(76);
     f_m.putInt32(m);
     f_n.putInt32(n);
     f_lda.putInt32(Math.max(1, m));
-    
-    callback(m, n, f_m, f_n, f_a, f_lda);
+   console.log(f_letter_u); 
+    callback(m, n, f_m, f_n, f_a, f_lda, f_letter_u, f_letter_l);
 }
 
 function zeroBottomLeft(matrix) {
@@ -193,6 +198,12 @@ function swapRows(matrix, i, j) {
     return matrix;
 }
 
+
+function cholesky(matrix) {
+    var result = spotrf(matrix);
+	return result;
+}
+
 function lu(matrix) {
     var result = sgetrf(matrix);
     var P = ipivToP(matrix.length, result.IPIV);
@@ -230,11 +241,28 @@ function ipivToP(m, ipiv){
 function sgetrf(matrix) {
     return getrf(matrix, LAPACK.sgetrf_, FORTRAN_FLOAT);
 }
+function spotrf(matrix) {
+    return potrf(matrix, LAPACK.spotrf_, FORTRAN_FLOAT);
+}
 
 function dgetrf(matrix) {
     return getrf(matrix, LAPACK.dgetrf_, FORTRAN_DOUBLE);
 }
 
+function potrf(matrix, lapackFunc, elementSize) {
+    var result = {};
+    matrixOp(matrix, elementSize, function(m, n, f_m, f_n, f_a, f_lda, f_letter_u, f_letter_l) {
+        //var f_ipiv = new FFI.Pointer(Math.min(m, n) * FORTRAN_INT);
+        var f_info = new FFI.Pointer(FORTRAN_INT);
+        lapackFunc(f_letter_u, f_n, f_a, f_lda, f_info);
+        result.cholesky = fortranArray.fortranArrayToJSMatrix(f_a, m, n, elementSize);
+        result.LDA = f_lda.getInt32(); //fortranArray.fortranArrayToJSMatrix(f_a, m, n, elementSize);
+	result.INFO = f_info.getInt32();
+        //result.IPIV = fortranArray.fortranArrayToJSArray(f_ipiv, Math.min(m, n), 'getInt', elementSize);
+    });
+
+    return result;
+}
 function getrf(matrix, lapackFunc, elementSize) {
     var result = {};
 
@@ -301,3 +329,4 @@ exports.dgetrf = sgetrf;
 exports.sgesv = sgesv;
 exports.qr = qr;
 exports.lu = lu;
+exports.cholesky = cholesky;

--- a/lib/node-lapack/lapack.js
+++ b/lib/node-lapack/lapack.js
@@ -38,6 +38,7 @@ try {
 			    "pointer", "pointer", "pointer", "pointer", ]],
 	"sgetrf_": ["void", ["pointer", "pointer", "pointer", "pointer", "pointer", "pointer"]],
 	"spotrf_": ["void", ["pointer", "pointer", "pointer", "pointer", "pointer"]],
+	"spotrs_": ["void", ["pointer", "pointer", "pointer", "pointer", "pointer", "pointer", "pointer", "pointer"]],
 	"dgetrf_": ["void", ["pointer", "pointer", "pointer", "pointer", "pointer", "pointer"]],
 	"sgesv_": ["void", ["pointer", "pointer", "pointer", "pointer", "pointer", "pointer", "pointer", "pointer"]]
 	
@@ -71,6 +72,7 @@ function eye(m) {
 }
 
 function matrixOp(matrix, elementSize, callback) {
+console.log(matrix);
     var m = matrix.length;
     var n = matrix[0].length;    
     var f_m = new FFI.Pointer(FORTRAN_INT);
@@ -85,7 +87,6 @@ function matrixOp(matrix, elementSize, callback) {
     f_m.putInt32(m);
     f_n.putInt32(n);
     f_lda.putInt32(Math.max(1, m));
-   console.log(f_letter_u); 
     callback(m, n, f_m, f_n, f_a, f_lda, f_letter_u, f_letter_l);
 }
 
@@ -199,8 +200,8 @@ function swapRows(matrix, i, j) {
 }
 
 
-function cholesky(matrix) {
-    var result = spotrf(matrix);
+function cholesky(matrix, upper_or_lower) {	// pass u or l in upper or lower
+    var result = spotrf(matrix, upper_or_lower);
 	return result;
 }
 
@@ -241,20 +242,65 @@ function ipivToP(m, ipiv){
 function sgetrf(matrix) {
     return getrf(matrix, LAPACK.sgetrf_, FORTRAN_FLOAT);
 }
-function spotrf(matrix) {
-    return potrf(matrix, LAPACK.spotrf_, FORTRAN_FLOAT);
+function spotrf(matrix, upper_or_lower) {
+    if(upper_or_lower == undefined) upper_or_lower = "u";
+    return potrf(matrix, LAPACK.spotrf_, FORTRAN_FLOAT, upper_or_lower.toLowerCase());
 }
+function spotrs(matrix, colvec, upper_or_lower) {
+    if(upper_or_lower == undefined) upper_or_lower = "u";
+    return potrs(matrix, colvec, LAPACK.spotrs_, FORTRAN_FLOAT, upper_or_lower.toLowerCase());
+}
+function choleskysolve(a, b) {
+	var cholup = spotrf(a, 'u');
+	return spotrs(a, b, 'u');
+}
+
 
 function dgetrf(matrix) {
     return getrf(matrix, LAPACK.dgetrf_, FORTRAN_DOUBLE);
 }
 
-function potrf(matrix, lapackFunc, elementSize) {
+function potrs(matrix, colvec, lapackFunc, elementSize, uorl) {
+//  SUBROUTINE SPOTRS( UPLO, N, NRHS, A, LDA, B, LDB, INFO )
+
+
+    var f_nrhs = new FFI.Pointer(FORTRAN_INT);
+    f_nrhs.putInt32(1);	// TODO: should be colvec width if colvec is a matrix. right now colvec is only a vector
+    var f_b = fortranArray.jsMatrixToFortranArray([colvec], elementSize);
+    var f_ldb = new FFI.Pointer(FORTRAN_INT);
+
+    f_ldb.putInt32(Math.max(1, colvec.length));
+
     var result = {};
     matrixOp(matrix, elementSize, function(m, n, f_m, f_n, f_a, f_lda, f_letter_u, f_letter_l) {
         //var f_ipiv = new FFI.Pointer(Math.min(m, n) * FORTRAN_INT);
         var f_info = new FFI.Pointer(FORTRAN_INT);
-        lapackFunc(f_letter_u, f_n, f_a, f_lda, f_info);
+
+        if(uorl == 'u')
+                lapackFunc(f_letter_u, f_n, f_nrhs, f_a, f_lda, f_b, f_ldb, f_info);
+        else
+                lapackFunc(f_letter_l, f_n, f_nrhs, f_a, f_lda, f_b, f_ldb, f_info);
+
+        result.cholesky = fortranArray.fortranArrayToJSMatrix(f_a, m, n, elementSize);
+        result.sol = fortranArray.fortranArrayToJSMatrix(f_b, 1, colvec.length, elementSize);
+        result.LDA = f_lda.getInt32(); //fortranArray.fortranArrayToJSMatrix(f_a, m, n, elementSize);
+        result.LDB = f_ldb.getInt32(); //fortranArray.fortranArrayToJSMatrix(f_a, m, n, elementSize);
+        result.INFO = f_info.getInt32();
+    });
+
+    return result;
+}
+
+function potrf(matrix, lapackFunc, elementSize, uorl) {
+    var result = {};
+    matrixOp(matrix, elementSize, function(m, n, f_m, f_n, f_a, f_lda, f_letter_u, f_letter_l) {
+        //var f_ipiv = new FFI.Pointer(Math.min(m, n) * FORTRAN_INT);
+        var f_info = new FFI.Pointer(FORTRAN_INT);
+	if(uorl == 'u')
+	        lapackFunc(f_letter_u, f_n, f_a, f_lda, f_info);
+	else
+	        lapackFunc(f_letter_l, f_n, f_a, f_lda, f_info);
+
         result.cholesky = fortranArray.fortranArrayToJSMatrix(f_a, m, n, elementSize);
         result.LDA = f_lda.getInt32(); //fortranArray.fortranArrayToJSMatrix(f_a, m, n, elementSize);
 	result.INFO = f_info.getInt32();
@@ -330,3 +376,4 @@ exports.sgesv = sgesv;
 exports.qr = qr;
 exports.lu = lu;
 exports.cholesky = cholesky;
+exports.choleskysolve = choleskysolve;


### PR DESCRIPTION
I've VERY messily added calls to two methods (cholesky and choleskySolve). 

```
"spotrf_": ["void", ["pointer", "pointer", "pointer", "pointer", "pointer"]],
"spotrs_": ["void", ["pointer", "pointer", "pointer", "pointer", "pointer", "pointer", "pointer", "pointer"]],
```

It works, but it does not do any parameter validation and is a lot of copy-pasta. Unfortunately, I did this months ago for a one-off experiment and never found the time to come back to it to clean up.

I would probably not recommend accepting this pull request as is, but perhaps it is worth someone else taking up this project and using my code. I've "solved" some of the type alignment problems here, so there is some value in the code.
